### PR TITLE
feat: Session Performance & Metrics Dashboard (Story 3.3)

### DIFF
--- a/dashboard/__tests__/components/performance/SessionPerformanceWidget.test.tsx
+++ b/dashboard/__tests__/components/performance/SessionPerformanceWidget.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * Tests for SessionPerformanceWidget component
+ */
+
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { SessionPerformanceWidget } from '@/components/performance/SessionPerformanceWidget'
+import { useSessionPerformance } from '@/hooks/useSessionPerformance'
+import { TradingSession } from '@/types/session'
+
+// Mock the hooks
+jest.mock('@/hooks/useSessionPerformance')
+jest.mock('date-fns', () => ({
+  ...jest.requireActual('date-fns'),
+  format: jest.fn((date) => new Date(date).toISOString().split('T')[0]),
+  startOfDay: jest.fn((date) => date),
+  endOfDay: jest.fn((date) => date),
+  startOfWeek: jest.fn((date) => date),
+  startOfMonth: jest.fn((date) => date)
+}))
+
+const mockUseSessionPerformance = useSessionPerformance as jest.MockedFunction<typeof useSessionPerformance>
+
+describe('SessionPerformanceWidget', () => {
+  const mockSessions = [
+    {
+      session: TradingSession.LONDON,
+      totalPnL: 1250.50,
+      tradeCount: 15,
+      winCount: 10,
+      winRate: 66.67,
+      confidenceThreshold: 72,
+      isActive: true
+    },
+    {
+      session: TradingSession.NEW_YORK,
+      totalPnL: -350.25,
+      tradeCount: 8,
+      winCount: 3,
+      winRate: 37.5,
+      confidenceThreshold: 70,
+      isActive: false
+    },
+    {
+      session: TradingSession.TOKYO,
+      totalPnL: 800.00,
+      tradeCount: 12,
+      winCount: 9,
+      winRate: 75,
+      confidenceThreshold: 85,
+      isActive: false
+    }
+  ]
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders loading state correctly', () => {
+    mockUseSessionPerformance.mockReturnValue({
+      sessions: [],
+      activeSession: null,
+      isLoading: true,
+      error: null,
+      refetch: jest.fn()
+    })
+
+    render(<SessionPerformanceWidget />)
+    expect(screen.getByText('Session Performance')).toBeInTheDocument()
+  })
+
+  it('renders session rows with correct data', () => {
+    mockUseSessionPerformance.mockReturnValue({
+      sessions: mockSessions,
+      activeSession: TradingSession.LONDON,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn()
+    })
+
+    render(<SessionPerformanceWidget />)
+
+    // Check session names are rendered
+    expect(screen.getByText('London')).toBeInTheDocument()
+    expect(screen.getByText('New York')).toBeInTheDocument()
+    expect(screen.getByText('Tokyo')).toBeInTheDocument()
+
+    // Check P&L values
+    expect(screen.getByText('$1,250.50')).toBeInTheDocument()
+    expect(screen.getByText('-$350.25')).toBeInTheDocument()
+    expect(screen.getByText('$800.00')).toBeInTheDocument()
+  })
+
+  it('displays active session indicator', () => {
+    mockUseSessionPerformance.mockReturnValue({
+      sessions: mockSessions,
+      activeSession: TradingSession.LONDON,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn()
+    })
+
+    render(<SessionPerformanceWidget />)
+
+    // Active indicator should be present for London session
+    const londonRow = screen.getByText('London').closest('button')
+    const activeIndicator = londonRow?.querySelector('.animate-pulse')
+    expect(activeIndicator).toBeInTheDocument()
+  })
+
+  it('shows error message when error occurs', () => {
+    mockUseSessionPerformance.mockReturnValue({
+      sessions: [],
+      activeSession: null,
+      isLoading: false,
+      error: 'Failed to fetch session data',
+      refetch: jest.fn()
+    })
+
+    render(<SessionPerformanceWidget />)
+    expect(screen.getByText('Failed to fetch session data')).toBeInTheDocument()
+  })
+
+  it('shows no data message when sessions array is empty', () => {
+    mockUseSessionPerformance.mockReturnValue({
+      sessions: [],
+      activeSession: null,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn()
+    })
+
+    render(<SessionPerformanceWidget />)
+    expect(screen.getByText('No session data available for selected date range')).toBeInTheDocument()
+  })
+
+  it('handles date range filter changes', async () => {
+    const mockRefetch = jest.fn()
+    mockUseSessionPerformance.mockReturnValue({
+      sessions: mockSessions,
+      activeSession: TradingSession.LONDON,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch
+    })
+
+    render(<SessionPerformanceWidget />)
+
+    // Click "This Week" filter
+    const weekButton = screen.getByText('This Week')
+    fireEvent.click(weekButton)
+
+    // Should call refetch when date range changes
+    await waitFor(() => {
+      expect(mockRefetch).toHaveBeenCalled()
+    })
+  })
+
+  it('exports CSV when export button is clicked', () => {
+    mockUseSessionPerformance.mockReturnValue({
+      sessions: mockSessions,
+      activeSession: TradingSession.LONDON,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn()
+    })
+
+    // Mock document.createElement and related DOM methods
+    const createElementSpy = jest.spyOn(document, 'createElement')
+    const appendChildSpy = jest.spyOn(document.body, 'appendChild').mockImplementation()
+    const removeChildSpy = jest.spyOn(document.body, 'removeChild').mockImplementation()
+
+    render(<SessionPerformanceWidget />)
+
+    const exportButton = screen.getByText('Export CSV')
+    fireEvent.click(exportButton)
+
+    // Verify CSV creation
+    expect(createElementSpy).toHaveBeenCalledWith('a')
+
+    // Cleanup
+    createElementSpy.mockRestore()
+    appendChildSpy.mockRestore()
+    removeChildSpy.mockRestore()
+  })
+})

--- a/dashboard/__tests__/hooks/useSessionPerformance.test.ts
+++ b/dashboard/__tests__/hooks/useSessionPerformance.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Tests for useSessionPerformance hook
+ */
+
+import { renderHook, waitFor } from '@testing-library/react'
+import { useSessionPerformance } from '@/hooks/useSessionPerformance'
+import { useWebSocket } from '@/hooks/useWebSocket'
+import { TradingSession } from '@/types/session'
+
+// Mock dependencies
+jest.mock('@/hooks/useWebSocket')
+
+global.fetch = jest.fn()
+
+const mockUseWebSocket = useWebSocket as jest.MockedFunction<typeof useWebSocket>
+
+describe('useSessionPerformance', () => {
+  const mockDateRange = {
+    start: new Date('2025-01-01'),
+    end: new Date('2025-01-31')
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseWebSocket.mockReturnValue({
+      connectionStatus: 'CONNECTED' as any,
+      lastMessage: null,
+      sendMessage: jest.fn(),
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+      isConnected: true,
+      reconnectCount: 0,
+      lastError: null
+    })
+  })
+
+  it('fetches session performance data on mount', async () => {
+    const mockResponse = {
+      sessions: [
+        {
+          session: 'london',
+          total_pnl: 1000,
+          trade_count: 10,
+          win_count: 7,
+          win_rate: 70,
+          confidence_threshold: 72
+        }
+      ]
+    }
+
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse
+    })
+
+    const { result } = renderHook(() =>
+      useSessionPerformance({ dateRange: mockDateRange })
+    )
+
+    expect(result.current.isLoading).toBe(true)
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.sessions).toHaveLength(1)
+    expect(result.current.sessions[0].session).toBe(TradingSession.LONDON)
+    expect(result.current.sessions[0].totalPnL).toBe(1000)
+  })
+
+  it('sets error state when fetch fails', async () => {
+    ;(global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'))
+
+    const { result } = renderHook(() =>
+      useSessionPerformance({ dateRange: mockDateRange })
+    )
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('Network error')
+    })
+  })
+
+  it('determines active session correctly', async () => {
+    // Mock current time to be in London session (14:00 GMT)
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2025-01-15T14:00:00Z'))
+
+    const mockResponse = {
+      sessions: [
+        {
+          session: 'london',
+          total_pnl: 1000,
+          trade_count: 10,
+          win_count: 7,
+          win_rate: 70,
+          confidence_threshold: 72
+        }
+      ]
+    }
+
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse
+    })
+
+    const { result } = renderHook(() =>
+      useSessionPerformance({ dateRange: mockDateRange })
+    )
+
+    await waitFor(() => {
+      expect(result.current.activeSession).toBe(TradingSession.LONDON)
+      expect(result.current.sessions[0].isActive).toBe(true)
+    })
+
+    jest.useRealTimers()
+  })
+
+  it('handles WebSocket trade completion messages', async () => {
+    const mockResponse = {
+      sessions: [
+        {
+          session: 'london',
+          total_pnl: 1000,
+          trade_count: 10,
+          win_count: 7,
+          win_rate: 70,
+          confidence_threshold: 72
+        }
+      ]
+    }
+
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse
+    })
+
+    const { result, rerender } = renderHook(() =>
+      useSessionPerformance({ dateRange: mockDateRange })
+    )
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    // Simulate WebSocket trade completion message
+    mockUseWebSocket.mockReturnValue({
+      connectionStatus: 'CONNECTED' as any,
+      lastMessage: {
+        type: 'trade.completed',
+        data: {
+          session: 'london',
+          pnL: 150,
+          timestamp: new Date().toISOString()
+        }
+      } as any,
+      sendMessage: jest.fn(),
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+      isConnected: true,
+      reconnectCount: 0,
+      lastError: null
+    })
+
+    rerender()
+
+    await waitFor(() => {
+      const londonSession = result.current.sessions.find(s => s.session === TradingSession.LONDON)
+      expect(londonSession?.totalPnL).toBe(1150) // 1000 + 150
+      expect(londonSession?.tradeCount).toBe(11) // 10 + 1
+    })
+  })
+
+  it('refetches data when refetch is called', async () => {
+    const mockResponse = {
+      sessions: [
+        {
+          session: 'london',
+          total_pnl: 1000,
+          trade_count: 10,
+          win_count: 7,
+          win_rate: 70,
+          confidence_threshold: 72
+        }
+      ]
+    }
+
+    ;(global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse
+    })
+
+    const { result } = renderHook(() =>
+      useSessionPerformance({ dateRange: mockDateRange })
+    )
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+
+    // Call refetch
+    result.current.refetch()
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/dashboard/app/performance-analytics/page.tsx
+++ b/dashboard/app/performance-analytics/page.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect } from 'react'
 import MainLayout from '@/components/layout/MainLayout'
 import ProtectedRoute from '@/components/auth/ProtectedRoute'
 import PerformanceAnalyticsDashboard from '@/components/analytics/PerformanceAnalyticsDashboard'
+import SessionPerformanceWidget from '@/components/performance/SessionPerformanceWidget'
+import PerformanceMetricsDashboard from '@/components/performance/PerformanceMetricsDashboard'
 import { performanceAnalyticsService } from '@/services/performanceAnalyticsService'
 import { TradeBreakdown, ComplianceReport } from '@/types/performanceAnalytics'
 
@@ -71,12 +73,21 @@ export default function PerformanceAnalyticsPage() {
   return (
     <ProtectedRoute>
       <MainLayout>
-        <PerformanceAnalyticsDashboard
-          accountIds={accountIds}
-          initialView="overview"
-          onTradeSelect={handleTradeSelect}
-          onReportGenerated={handleReportGenerated}
-        />
+        <div className="space-y-8">
+          {/* Story 3.3: Session Performance Widget */}
+          <SessionPerformanceWidget />
+
+          {/* Story 3.3: Performance Metrics Dashboard */}
+          <PerformanceMetricsDashboard period="30d" equityDays={30} />
+
+          {/* Existing Performance Analytics Dashboard */}
+          <PerformanceAnalyticsDashboard
+            accountIds={accountIds}
+            initialView="overview"
+            onTradeSelect={handleTradeSelect}
+            onReportGenerated={handleReportGenerated}
+          />
+        </div>
       </MainLayout>
     </ProtectedRoute>
   )

--- a/dashboard/components/performance/AverageTradeMetrics.tsx
+++ b/dashboard/components/performance/AverageTradeMetrics.tsx
@@ -1,0 +1,165 @@
+/**
+ * Average Trade Metrics Component
+ * Displays average trade statistics with period-over-period comparison
+ */
+
+'use client'
+
+import React, { useMemo } from 'react'
+import { PerformanceMetrics } from '@/types/metrics'
+import { formatCurrency } from '@/utils/formatCurrency'
+import { cn } from '@/lib/utils'
+
+interface AverageTradeMetricsProps {
+  /** Current period metrics */
+  current: PerformanceMetrics
+  /** Previous period metrics for comparison (optional) */
+  previous?: PerformanceMetrics | null
+}
+
+/**
+ * Calculate percentage change between periods
+ */
+function calculateChange(current: number, previous: number | undefined): {
+  percentage: number
+  isPositive: boolean
+  arrow: string
+} {
+  if (!previous || previous === 0) {
+    return { percentage: 0, isPositive: false, arrow: '' }
+  }
+
+  const change = ((current - previous) / Math.abs(previous)) * 100
+  const isPositive = change > 0
+
+  return {
+    percentage: Math.abs(change),
+    isPositive,
+    arrow: isPositive ? '↑' : '↓'
+  }
+}
+
+/**
+ * Format duration from hours to human-readable
+ */
+function formatDuration(hours: number): string {
+  if (hours < 1) {
+    const minutes = Math.round(hours * 60)
+    return `${minutes}m`
+  }
+
+  const wholeHours = Math.floor(hours)
+  const minutes = Math.round((hours - wholeHours) * 60)
+
+  if (minutes === 0) {
+    return `${wholeHours}h`
+  }
+
+  return `${wholeHours}h ${minutes}m`
+}
+
+/**
+ * Metric card component
+ */
+function MetricCard({
+  title,
+  value,
+  previous,
+  colorClass,
+  isBetter
+}: {
+  title: string
+  value: string
+  previous?: number
+  colorClass: string
+  isBetter?: (change: number) => boolean
+}) {
+  const change = useMemo(() => {
+    if (previous === undefined) return null
+
+    const currentNum = parseFloat(value.replace(/[$,]/g, ''))
+    return calculateChange(currentNum, previous)
+  }, [value, previous])
+
+  const showComparison = change && change.percentage !== 0
+
+  // Determine if change is good (green) or bad (red)
+  const isGoodChange = useMemo(() => {
+    if (!change || !isBetter) return false
+    return isBetter(change.isPositive ? change.percentage : -change.percentage)
+  }, [change, isBetter])
+
+  return (
+    <div className="flex flex-col">
+      <div className="text-sm text-gray-400 mb-1">{title}</div>
+      <div className={cn('text-2xl font-bold', colorClass)}>{value}</div>
+      {showComparison && (
+        <div className={cn(
+          'text-xs mt-1 flex items-center space-x-1',
+          isGoodChange ? 'text-green-400' : 'text-red-400'
+        )}>
+          <span>{change!.arrow}</span>
+          <span>{change!.percentage.toFixed(1)}%</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Average trade metrics component
+ */
+export function AverageTradeMetrics({ current, previous }: AverageTradeMetricsProps) {
+  return (
+    <div className="bg-gray-800 rounded-lg p-6">
+      <h3 className="text-lg font-semibold text-white mb-6">Average Trade Metrics</h3>
+
+      <div className="grid grid-cols-2 gap-6">
+        {/* Average Win */}
+        <MetricCard
+          title="Average Win"
+          value={formatCurrency(current.avgWin)}
+          previous={previous?.avgWin}
+          colorClass="text-green-400"
+          isBetter={(change) => change > 0}
+        />
+
+        {/* Average Loss */}
+        <MetricCard
+          title="Average Loss"
+          value={formatCurrency(current.avgLoss)}
+          previous={previous?.avgLoss}
+          colorClass="text-red-400"
+          isBetter={(change) => change < 0} // Lower loss is better
+        />
+
+        {/* Average R:R */}
+        <MetricCard
+          title="Average R:R"
+          value={`${current.avgRiskReward.toFixed(2)}:1`}
+          previous={previous?.avgRiskReward}
+          colorClass="text-blue-400"
+          isBetter={(change) => change > 0}
+        />
+
+        {/* Average Duration */}
+        <MetricCard
+          title="Avg Duration"
+          value={formatDuration(current.avgDurationHours)}
+          previous={previous?.avgDurationHours}
+          colorClass="text-gray-300"
+          isBetter={(change) => change < 0} // Shorter duration can be better
+        />
+      </div>
+
+      {/* Period Comparison Note */}
+      {previous && (
+        <div className="mt-4 pt-4 border-t border-gray-700 text-xs text-gray-400 text-center">
+          Compared to previous period
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default AverageTradeMetrics

--- a/dashboard/components/performance/EquityCurveChart.tsx
+++ b/dashboard/components/performance/EquityCurveChart.tsx
@@ -1,0 +1,205 @@
+/**
+ * Equity Curve Chart Component
+ * Line chart showing 30-day equity progression with peak/trough markers
+ */
+
+'use client'
+
+import React, { useMemo } from 'react'
+import { Line } from 'react-chartjs-2'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+  Filler
+} from 'chart.js'
+import { EquityCurveData } from '@/types/metrics'
+import { format } from 'date-fns'
+import { formatCurrency } from '@/utils/formatCurrency'
+
+// Register Chart.js components
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+  Filler
+)
+
+interface EquityCurveChartProps {
+  /** Equity curve data */
+  data: EquityCurveData
+}
+
+/**
+ * Equity curve chart component
+ */
+export function EquityCurveChart({ data }: EquityCurveChartProps) {
+  // Prepare chart data
+  const chartData = useMemo(() => {
+    const labels = data.points.map(p => format(new Date(p.date), 'MMM dd'))
+    const equityValues = data.points.map(p => p.equity)
+
+    // Find indices for peak and trough
+    const peakIndex = data.peak ? data.points.findIndex(p => p.date === data.peak!.date) : -1
+    const troughIndex = data.trough ? data.points.findIndex(p => p.date === data.trough!.date) : -1
+
+    // Create point colors array (highlight peak and trough)
+    const pointColors = data.points.map((_, index) => {
+      if (index === peakIndex) return '#4ade80' // green for peak
+      if (index === troughIndex) return '#f87171' // red for trough
+      return 'transparent'
+    })
+
+    // Create point radius array (larger for peak and trough)
+    const pointRadius = data.points.map((_, index) => {
+      if (index === peakIndex || index === troughIndex) return 6
+      return 0
+    })
+
+    return {
+      labels,
+      datasets: [
+        {
+          label: 'Equity',
+          data: equityValues,
+          borderColor: '#4ade80', // green-400
+          backgroundColor: 'rgba(74, 222, 128, 0.1)',
+          borderWidth: 2,
+          fill: true,
+          tension: 0.4,
+          pointBackgroundColor: pointColors,
+          pointBorderColor: pointColors,
+          pointRadius: pointRadius,
+          pointHoverRadius: pointRadius.map(r => r > 0 ? 8 : 3)
+        }
+      ]
+    }
+  }, [data])
+
+  // Chart options
+  const chartOptions = useMemo(() => ({
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        display: false
+      },
+      tooltip: {
+        mode: 'index' as const,
+        intersect: false,
+        backgroundColor: '#1f2937',
+        titleColor: '#fff',
+        bodyColor: '#9ca3af',
+        borderColor: '#374151',
+        borderWidth: 1,
+        padding: 12,
+        displayColors: false,
+        callbacks: {
+          label: (context: any) => {
+            const point = data.points[context.dataIndex]
+            const equity = formatCurrency(point.equity)
+            const dailyPnL = formatCurrency(point.dailyPnL)
+            const dailyLabel = point.dailyPnL >= 0 ? '+' + dailyPnL : dailyPnL
+
+            return [
+              `Equity: ${equity}`,
+              `Daily P&L: ${dailyLabel}`
+            ]
+          },
+          title: (context: any) => {
+            return format(new Date(data.points[context[0].dataIndex].date), 'MMM dd, yyyy')
+          }
+        }
+      }
+    },
+    scales: {
+      x: {
+        grid: {
+          color: '#374151',
+          display: true
+        },
+        ticks: {
+          color: '#9ca3af',
+          maxRotation: 45,
+          minRotation: 45
+        }
+      },
+      y: {
+        grid: {
+          color: '#374151',
+          display: true
+        },
+        ticks: {
+          color: '#9ca3af',
+          callback: (value: any) => {
+            // Format as $Xk for thousands
+            if (value >= 1000) {
+              return `$${(value / 1000).toFixed(1)}k`
+            }
+            return `$${value}`
+          }
+        }
+      }
+    },
+    interaction: {
+      mode: 'nearest' as const,
+      axis: 'x' as const,
+      intersect: false
+    }
+  }), [data.points])
+
+  return (
+    <div className="bg-gray-800 rounded-lg p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-white">30-Day Equity Curve</h3>
+
+        {/* Drawdown Badge */}
+        {data.currentDrawdown < 0 && (
+          <div className="text-sm">
+            <span className="text-gray-400">Current DD: </span>
+            <span className="text-red-400 font-semibold">
+              {data.currentDrawdown.toFixed(2)}%
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Chart */}
+      <div className="h-64">
+        <Line data={chartData} options={chartOptions} />
+      </div>
+
+      {/* Legend */}
+      <div className="mt-4 flex items-center justify-center space-x-6 text-xs text-gray-400">
+        {data.peak && (
+          <div className="flex items-center space-x-2">
+            <div className="w-3 h-3 rounded-full bg-green-400" />
+            <span>Peak: {formatCurrency(data.peak.equity)}</span>
+          </div>
+        )}
+        {data.trough && (
+          <div className="flex items-center space-x-2">
+            <div className="w-3 h-3 rounded-full bg-red-400" />
+            <span>Trough: {formatCurrency(data.trough.equity)}</span>
+          </div>
+        )}
+        {data.maxDrawdown < 0 && (
+          <div className="flex items-center space-x-2">
+            <span>Max DD: {data.maxDrawdown.toFixed(2)}%</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default EquityCurveChart

--- a/dashboard/components/performance/PerformanceMetricsDashboard.tsx
+++ b/dashboard/components/performance/PerformanceMetricsDashboard.tsx
@@ -1,0 +1,101 @@
+/**
+ * Performance Metrics Dashboard Component
+ * 2x2 grid of key performance widgets
+ */
+
+'use client'
+
+import React from 'react'
+import { usePerformanceMetrics } from '@/hooks/usePerformanceMetrics'
+import { useEquityCurve } from '@/hooks/useEquityCurve'
+import WinRateGauge from './WinRateGauge'
+import ProfitFactorDisplay from './ProfitFactorDisplay'
+import AverageTradeMetrics from './AverageTradeMetrics'
+import EquityCurveChart from './EquityCurveChart'
+import { LoadingSkeleton } from '@/components/ui/LoadingSkeleton'
+
+interface PerformanceMetricsDashboardProps {
+  /** Metrics period (default: 30d) */
+  period?: '7d' | '30d' | '90d' | 'all'
+  /** Equity curve days (default: 30) */
+  equityDays?: number
+}
+
+/**
+ * Performance metrics dashboard component
+ */
+export function PerformanceMetricsDashboard({
+  period = '30d',
+  equityDays = 30
+}: PerformanceMetricsDashboardProps = {}) {
+  const { metrics, previousMetrics, isLoading: metricsLoading, error: metricsError } = usePerformanceMetrics({ period })
+  const { equityCurve, isLoading: equityLoading, error: equityError } = useEquityCurve({ days: equityDays })
+
+  const isLoading = metricsLoading || equityLoading
+  const error = metricsError || equityError
+
+  // Loading skeleton
+  if (isLoading) {
+    return (
+      <section className="space-y-6">
+        <h2 className="text-2xl font-bold text-white">Performance Metrics</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <LoadingSkeleton className="h-80" />
+          <LoadingSkeleton className="h-80" />
+          <LoadingSkeleton className="h-80" />
+          <LoadingSkeleton className="h-80" />
+        </div>
+      </section>
+    )
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <section className="space-y-6">
+        <h2 className="text-2xl font-bold text-white">Performance Metrics</h2>
+        <div className="p-4 bg-red-500/10 border border-red-500/30 rounded-lg text-red-400 text-sm">
+          {error}
+        </div>
+      </section>
+    )
+  }
+
+  // No data state
+  if (!metrics || !equityCurve) {
+    return (
+      <section className="space-y-6">
+        <h2 className="text-2xl font-bold text-white">Performance Metrics</h2>
+        <div className="text-center text-gray-400 py-12">
+          No performance data available
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <section className="space-y-6">
+      <h2 className="text-2xl font-bold text-white">Performance Metrics</h2>
+
+      {/* 2x2 Grid Layout */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* Top Left: Win Rate Gauge */}
+        <WinRateGauge winRate={metrics.winRate} />
+
+        {/* Top Right: Profit Factor */}
+        <ProfitFactorDisplay profitFactor={metrics.profitFactor} />
+
+        {/* Bottom Left: Average Trade Metrics */}
+        <AverageTradeMetrics
+          current={metrics}
+          previous={previousMetrics}
+        />
+
+        {/* Bottom Right: Equity Curve */}
+        <EquityCurveChart data={equityCurve} />
+      </div>
+    </section>
+  )
+}
+
+export default PerformanceMetricsDashboard

--- a/dashboard/components/performance/ProfitFactorDisplay.tsx
+++ b/dashboard/components/performance/ProfitFactorDisplay.tsx
@@ -1,0 +1,114 @@
+/**
+ * Profit Factor Display Component
+ * Displays profit factor with interpretation and color coding
+ */
+
+'use client'
+
+import React, { useMemo } from 'react'
+import { ProfitFactorDisplay as ProfitFactorData, ProfitFactorRating } from '@/types/metrics'
+import { cn } from '@/lib/utils'
+
+interface ProfitFactorDisplayProps {
+  /** Profit factor value */
+  profitFactor: number
+}
+
+/**
+ * Get profit factor rating and styling
+ */
+function getProfitFactorRating(profitFactor: number): ProfitFactorData {
+  if (profitFactor >= 2) {
+    return {
+      value: profitFactor,
+      rating: 'excellent',
+      color: '#4ade80', // green-400
+      label: 'Excellent'
+    }
+  } else if (profitFactor >= 1.5) {
+    return {
+      value: profitFactor,
+      rating: 'good',
+      color: '#fbbf24', // yellow-400
+      label: 'Good'
+    }
+  } else if (profitFactor >= 1) {
+    return {
+      value: profitFactor,
+      rating: 'fair',
+      color: '#fb923c', // orange-400
+      label: 'Fair'
+    }
+  } else {
+    return {
+      value: profitFactor,
+      rating: 'poor',
+      color: '#f87171', // red-400
+      label: 'Poor'
+    }
+  }
+}
+
+/**
+ * Profit factor display component
+ */
+export function ProfitFactorDisplay({ profitFactor }: ProfitFactorDisplayProps) {
+  const data = useMemo(() => getProfitFactorRating(profitFactor), [profitFactor])
+
+  // Text color class based on rating
+  const textColorClass = useMemo(() => {
+    switch (data.rating) {
+      case 'excellent':
+        return 'text-green-400'
+      case 'good':
+        return 'text-yellow-400'
+      case 'fair':
+        return 'text-orange-400'
+      case 'poor':
+        return 'text-red-400'
+      default:
+        return 'text-gray-400'
+    }
+  }, [data.rating])
+
+  return (
+    <div className="bg-gray-800 rounded-lg p-6 flex flex-col items-center justify-center">
+      <h3 className="text-lg font-semibold text-white mb-4">Profit Factor</h3>
+
+      {/* Large Number Display */}
+      <div className={cn('text-5xl font-bold mb-4', textColorClass)}>
+        {data.value.toFixed(2)}
+      </div>
+
+      {/* Interpretation Label */}
+      <div className={cn('text-base font-medium mb-4', textColorClass)}>
+        {data.label}
+      </div>
+
+      {/* Tooltip / Explanation */}
+      <div className="text-xs text-gray-400 text-center max-w-xs">
+        <p className="mb-2">Gross Profit ÷ Gross Loss</p>
+        <div className="flex flex-col space-y-1 text-left">
+          <div className="flex items-center justify-between">
+            <span className="text-green-400">≥2.0</span>
+            <span className="ml-2">Excellent</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-yellow-400">1.5-2.0</span>
+            <span className="ml-2">Good</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-orange-400">1.0-1.5</span>
+            <span className="ml-2">Fair</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-red-400">&lt;1.0</span>
+            <span className="ml-2">Poor</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ProfitFactorDisplay

--- a/dashboard/components/performance/SessionDetailModal.tsx
+++ b/dashboard/components/performance/SessionDetailModal.tsx
@@ -1,0 +1,307 @@
+/**
+ * Session Detail Modal Component
+ * Displays detailed trade information for a specific trading session
+ */
+
+'use client'
+
+import React, { useState, useEffect, useMemo } from 'react'
+import Modal from '@/components/ui/Modal'
+import { TradingSession, SessionTrade, SESSION_CONFIG } from '@/types/session'
+import { formatCurrency } from '@/utils/formatCurrency'
+import { cn } from '@/lib/utils'
+
+interface SessionDetailModalProps {
+  /** Is modal open */
+  isOpen: boolean
+  /** Close handler */
+  onClose: () => void
+  /** Selected session */
+  session: TradingSession | null
+  /** Date range for filtering trades */
+  startDate: Date
+  /** Date range for filtering trades */
+  endDate: Date
+}
+
+type SortColumn = 'timestamp' | 'pnl' | 'duration' | 'instrument'
+type SortDirection = 'asc' | 'desc'
+
+/**
+ * Session detail modal displaying trades for selected session
+ */
+export function SessionDetailModal({
+  isOpen,
+  onClose,
+  session,
+  startDate,
+  endDate
+}: SessionDetailModalProps) {
+  const [trades, setTrades] = useState<SessionTrade[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [sortColumn, setSortColumn] = useState<SortColumn>('timestamp')
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
+
+  const config = session ? SESSION_CONFIG[session] : null
+
+  /**
+   * Fetch trades for selected session
+   */
+  useEffect(() => {
+    if (!isOpen || !session) return
+
+    const fetchTrades = async () => {
+      try {
+        setIsLoading(true)
+
+        const params = new URLSearchParams({
+          session,
+          start_date: startDate.toISOString(),
+          end_date: endDate.toISOString()
+        })
+
+        const response = await fetch(`http://localhost:8089/api/performance/session-trades?${params}`)
+
+        if (!response.ok) {
+          throw new Error('Failed to fetch session trades')
+        }
+
+        const data = await response.json()
+
+        const mappedTrades: SessionTrade[] = data.trades.map((t: any) => ({
+          id: t.id,
+          timestamp: new Date(t.timestamp),
+          instrument: t.instrument,
+          direction: t.direction,
+          pnL: t.pnl || t.pnL,
+          duration: t.duration
+        }))
+
+        setTrades(mappedTrades)
+      } catch (error) {
+        console.error('Error fetching session trades:', error)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchTrades()
+  }, [isOpen, session, startDate, endDate])
+
+  /**
+   * Calculate summary statistics
+   */
+  const stats = useMemo(() => {
+    if (trades.length === 0) {
+      return {
+        totalPnL: 0,
+        winRate: 0,
+        avgTrade: 0,
+        totalTrades: 0
+      }
+    }
+
+    const totalPnL = trades.reduce((sum, t) => sum + t.pnL, 0)
+    const winningTrades = trades.filter(t => t.pnL > 0).length
+    const winRate = (winningTrades / trades.length) * 100
+    const avgTrade = totalPnL / trades.length
+
+    return {
+      totalPnL,
+      winRate,
+      avgTrade,
+      totalTrades: trades.length
+    }
+  }, [trades])
+
+  /**
+   * Sort trades
+   */
+  const sortedTrades = useMemo(() => {
+    const sorted = [...trades]
+
+    sorted.sort((a, b) => {
+      let comparison = 0
+
+      switch (sortColumn) {
+        case 'timestamp':
+          comparison = a.timestamp.getTime() - b.timestamp.getTime()
+          break
+        case 'pnl':
+          comparison = a.pnL - b.pnL
+          break
+        case 'duration':
+          comparison = a.duration - b.duration
+          break
+        case 'instrument':
+          comparison = a.instrument.localeCompare(b.instrument)
+          break
+      }
+
+      return sortDirection === 'asc' ? comparison : -comparison
+    })
+
+    return sorted
+  }, [trades, sortColumn, sortDirection])
+
+  /**
+   * Handle column sort
+   */
+  const handleSort = (column: SortColumn) => {
+    if (sortColumn === column) {
+      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSortColumn(column)
+      setSortDirection('desc')
+    }
+  }
+
+  /**
+   * Format duration (seconds to human-readable)
+   */
+  const formatDuration = (seconds: number): string => {
+    const hours = Math.floor(seconds / 3600)
+    const minutes = Math.floor((seconds % 3600) / 60)
+
+    if (hours > 0) {
+      return `${hours}h ${minutes}m`
+    }
+    return `${minutes}m`
+  }
+
+  /**
+   * Sort indicator component
+   */
+  const SortIndicator = ({ column }: { column: SortColumn }) => {
+    if (sortColumn !== column) return null
+
+    return (
+      <span className="ml-1">
+        {sortDirection === 'asc' ? '↑' : '↓'}
+      </span>
+    )
+  }
+
+  if (!session || !config) return null
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={`${config.name} Session Trades`}
+      size="xl"
+    >
+      <div className="space-y-4">
+        {/* Summary Stats */}
+        <div className="grid grid-cols-4 gap-4 p-4 bg-gray-800 rounded-lg">
+          <div>
+            <div className="text-sm text-gray-400">Total P&L</div>
+            <div className={cn(
+              'text-xl font-bold',
+              stats.totalPnL > 0 ? 'text-green-400' : 'text-red-400'
+            )}>
+              {formatCurrency(stats.totalPnL)}
+            </div>
+          </div>
+          <div>
+            <div className="text-sm text-gray-400">Win Rate</div>
+            <div className="text-xl font-bold text-white">
+              {stats.winRate.toFixed(1)}%
+            </div>
+          </div>
+          <div>
+            <div className="text-sm text-gray-400">Avg Trade</div>
+            <div className={cn(
+              'text-xl font-bold',
+              stats.avgTrade > 0 ? 'text-green-400' : 'text-red-400'
+            )}>
+              {formatCurrency(stats.avgTrade)}
+            </div>
+          </div>
+          <div>
+            <div className="text-sm text-gray-400">Total Trades</div>
+            <div className="text-xl font-bold text-white">
+              {stats.totalTrades}
+            </div>
+          </div>
+        </div>
+
+        {/* Trades Table */}
+        {isLoading ? (
+          <div className="text-center text-gray-400 py-8">Loading trades...</div>
+        ) : trades.length === 0 ? (
+          <div className="text-center text-gray-400 py-8">No trades found for this session</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="bg-gray-800">
+                <tr>
+                  <th
+                    className="px-4 py-3 text-left text-sm font-semibold text-gray-300 cursor-pointer hover:text-white"
+                    onClick={() => handleSort('timestamp')}
+                  >
+                    Timestamp <SortIndicator column="timestamp" />
+                  </th>
+                  <th
+                    className="px-4 py-3 text-left text-sm font-semibold text-gray-300 cursor-pointer hover:text-white"
+                    onClick={() => handleSort('instrument')}
+                  >
+                    Instrument <SortIndicator column="instrument" />
+                  </th>
+                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-300">
+                    Direction
+                  </th>
+                  <th
+                    className="px-4 py-3 text-right text-sm font-semibold text-gray-300 cursor-pointer hover:text-white"
+                    onClick={() => handleSort('pnl')}
+                  >
+                    P&L <SortIndicator column="pnl" />
+                  </th>
+                  <th
+                    className="px-4 py-3 text-right text-sm font-semibold text-gray-300 cursor-pointer hover:text-white"
+                    onClick={() => handleSort('duration')}
+                  >
+                    Duration <SortIndicator column="duration" />
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-700">
+                {sortedTrades.map((trade) => (
+                  <tr key={trade.id} className="hover:bg-gray-800/50">
+                    <td className="px-4 py-3 text-sm text-gray-300">
+                      {trade.timestamp.toLocaleString()}
+                    </td>
+                    <td className="px-4 py-3 text-sm font-medium text-white">
+                      {trade.instrument}
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      <span className={cn(
+                        'px-2 py-1 rounded text-xs font-semibold',
+                        trade.direction === 'long'
+                          ? 'bg-blue-500/10 text-blue-400'
+                          : 'bg-orange-500/10 text-orange-400'
+                      )}>
+                        {trade.direction.toUpperCase()}
+                      </span>
+                    </td>
+                    <td className={cn(
+                      'px-4 py-3 text-sm font-bold text-right',
+                      trade.pnL > 0 ? 'text-green-400' : 'text-red-400'
+                    )}>
+                      {formatCurrency(trade.pnL)}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-400 text-right">
+                      {formatDuration(trade.duration)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </Modal>
+  )
+}
+
+export default SessionDetailModal

--- a/dashboard/components/performance/SessionPerformanceWidget.tsx
+++ b/dashboard/components/performance/SessionPerformanceWidget.tsx
@@ -1,0 +1,249 @@
+/**
+ * Session Performance Widget Component
+ * Main widget displaying session-based P&L breakdown with date filtering
+ */
+
+'use client'
+
+import React, { useState, useMemo } from 'react'
+import { DateRange, DateRangePreset, TradingSession } from '@/types/session'
+import { useSessionPerformance } from '@/hooks/useSessionPerformance'
+import SessionRow from './SessionRow'
+import SessionDetailModal from './SessionDetailModal'
+import { LoadingSkeleton } from '@/components/ui/LoadingSkeleton'
+import { startOfDay, endOfDay, startOfWeek, startOfMonth, format } from 'date-fns'
+
+/**
+ * Date range filter component
+ */
+function DateRangeFilter({
+  value,
+  onChange
+}: {
+  value: DateRange
+  onChange: (range: DateRange) => void
+}) {
+  const [activePreset, setActivePreset] = useState<DateRangePreset>('today')
+  const [showCustomPicker, setShowCustomPicker] = useState(false)
+
+  const handlePresetChange = (preset: DateRangePreset) => {
+    setActivePreset(preset)
+    setShowCustomPicker(false)
+
+    const now = new Date()
+
+    switch (preset) {
+      case 'today':
+        onChange({
+          start: startOfDay(now),
+          end: endOfDay(now)
+        })
+        break
+      case 'week':
+        onChange({
+          start: startOfWeek(now),
+          end: endOfDay(now)
+        })
+        break
+      case 'month':
+        onChange({
+          start: startOfMonth(now),
+          end: endOfDay(now)
+        })
+        break
+      case 'custom':
+        setShowCustomPicker(true)
+        break
+    }
+  }
+
+  return (
+    <div className="flex items-center space-x-2">
+      <button
+        onClick={() => handlePresetChange('today')}
+        className={`px-3 py-1 rounded text-sm transition-colors ${
+          activePreset === 'today'
+            ? 'bg-blue-600 text-white'
+            : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+        }`}
+      >
+        Today
+      </button>
+      <button
+        onClick={() => handlePresetChange('week')}
+        className={`px-3 py-1 rounded text-sm transition-colors ${
+          activePreset === 'week'
+            ? 'bg-blue-600 text-white'
+            : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+        }`}
+      >
+        This Week
+      </button>
+      <button
+        onClick={() => handlePresetChange('month')}
+        className={`px-3 py-1 rounded text-sm transition-colors ${
+          activePreset === 'month'
+            ? 'bg-blue-600 text-white'
+            : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+        }`}
+      >
+        This Month
+      </button>
+      <button
+        onClick={() => handlePresetChange('custom')}
+        className={`px-3 py-1 rounded text-sm transition-colors ${
+          activePreset === 'custom'
+            ? 'bg-blue-600 text-white'
+            : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+        }`}
+      >
+        Custom
+      </button>
+
+      {showCustomPicker && (
+        <div className="flex items-center space-x-2 ml-4">
+          <input
+            type="date"
+            value={format(value.start, 'yyyy-MM-dd')}
+            onChange={(e) => onChange({ ...value, start: new Date(e.target.value) })}
+            className="px-2 py-1 bg-gray-700 text-white text-sm rounded border border-gray-600"
+          />
+          <span className="text-gray-400">to</span>
+          <input
+            type="date"
+            value={format(value.end, 'yyyy-MM-dd')}
+            onChange={(e) => onChange({ ...value, end: new Date(e.target.value) })}
+            className="px-2 py-1 bg-gray-700 text-white text-sm rounded border border-gray-600"
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Export sessions to CSV
+ */
+function exportSessionsToCSV(sessions: any[], dateRange: DateRange) {
+  const headers = ['Session', 'Total P&L', 'Trade Count', 'Win Rate (%)', 'Confidence Threshold (%)']
+  const rows = sessions.map(s => [
+    s.session,
+    s.totalPnL.toFixed(2),
+    s.tradeCount,
+    s.winRate.toFixed(2),
+    s.confidenceThreshold
+  ])
+
+  const csv = [
+    headers.join(','),
+    ...rows.map(row => row.join(','))
+  ].join('\n')
+
+  const blob = new Blob([csv], { type: 'text/csv' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `session_performance_${format(dateRange.start, 'yyyy-MM-dd')}_to_${format(dateRange.end, 'yyyy-MM-dd')}.csv`
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+
+/**
+ * Session performance widget
+ */
+export function SessionPerformanceWidget() {
+  const [dateRange, setDateRange] = useState<DateRange>({
+    start: startOfDay(new Date()),
+    end: endOfDay(new Date())
+  })
+
+  const [selectedSession, setSelectedSession] = useState<TradingSession | null>(null)
+  const [isDetailModalOpen, setIsDetailModalOpen] = useState(false)
+
+  const { sessions, isLoading, error } = useSessionPerformance({ dateRange })
+
+  // Calculate max P&L for bar scaling
+  const maxPnL = useMemo(() => {
+    if (sessions.length === 0) return 1
+    return Math.max(...sessions.map(s => Math.abs(s.totalPnL)), 1)
+  }, [sessions])
+
+  const handleSessionClick = (session: TradingSession) => {
+    setSelectedSession(session)
+    setIsDetailModalOpen(true)
+  }
+
+  const handleExportCSV = () => {
+    exportSessionsToCSV(sessions, dateRange)
+  }
+
+  return (
+    <section className="bg-gray-800 rounded-lg p-6 shadow-lg">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-2xl font-bold text-white">Session Performance</h2>
+        <div className="flex items-center space-x-4">
+          <DateRangeFilter value={dateRange} onChange={setDateRange} />
+          <button
+            onClick={handleExportCSV}
+            disabled={sessions.length === 0}
+            className="px-3 py-1 text-sm text-blue-400 hover:text-blue-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            aria-label="Export session data as CSV"
+          >
+            Export CSV
+          </button>
+        </div>
+      </div>
+
+      {/* Error State */}
+      {error && (
+        <div className="p-4 bg-red-500/10 border border-red-500/30 rounded-lg text-red-400 text-sm">
+          {error}
+        </div>
+      )}
+
+      {/* Loading State */}
+      {isLoading ? (
+        <div className="space-y-3">
+          {[...Array(5)].map((_, i) => (
+            <LoadingSkeleton key={i} className="h-20 rounded-lg" />
+          ))}
+        </div>
+      ) : (
+        <>
+          {/* Session Rows */}
+          {sessions.length === 0 ? (
+            <div className="text-center text-gray-400 py-8">
+              No session data available for selected date range
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {sessions.map(session => (
+                <SessionRow
+                  key={session.session}
+                  session={session}
+                  maxPnL={maxPnL}
+                  isActive={session.isActive}
+                  onClick={() => handleSessionClick(session.session)}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Detail Modal */}
+      <SessionDetailModal
+        isOpen={isDetailModalOpen}
+        onClose={() => setIsDetailModalOpen(false)}
+        session={selectedSession}
+        startDate={dateRange.start}
+        endDate={dateRange.end}
+      />
+    </section>
+  )
+}
+
+export default SessionPerformanceWidget

--- a/dashboard/components/performance/SessionRow.tsx
+++ b/dashboard/components/performance/SessionRow.tsx
@@ -1,0 +1,119 @@
+/**
+ * Session Row Component
+ * Individual session performance row with P&L, metrics, and progress bar
+ */
+
+'use client'
+
+import React from 'react'
+import { SessionPerformance, SESSION_CONFIG } from '@/types/session'
+import { Badge } from '@/components/ui/Badge'
+import { formatCurrency } from '@/utils/formatCurrency'
+import { cn } from '@/lib/utils'
+
+interface SessionRowProps {
+  /** Session performance data */
+  session: SessionPerformance
+  /** Maximum P&L across all sessions for bar scaling */
+  maxPnL: number
+  /** Is this session currently active */
+  isActive: boolean
+  /** Click handler for drill-down */
+  onClick: () => void
+}
+
+/**
+ * Session row component displaying performance metrics
+ */
+export function SessionRow({ session, maxPnL, isActive, onClick }: SessionRowProps) {
+  const config = SESSION_CONFIG[session.session]
+
+  // Calculate bar width (percentage of max P&L)
+  const barWidth = maxPnL > 0 ? (Math.abs(session.totalPnL) / maxPnL) * 100 : 0
+
+  // Determine bar color based on P&L
+  const barColorClass = session.tradeCount === 0
+    ? 'bg-gray-500'
+    : session.totalPnL > 0
+    ? 'bg-green-500'
+    : 'bg-red-500'
+
+  // Determine text color
+  const pnlColorClass = session.totalPnL > 0
+    ? 'text-green-400'
+    : session.totalPnL < 0
+    ? 'text-red-400'
+    : 'text-gray-400'
+
+  // Win rate badge variant
+  const winRateVariant = session.winRate >= 60
+    ? 'success'
+    : session.winRate >= 40
+    ? 'warning'
+    : 'danger'
+
+  // Format session hours
+  const sessionHours = `${String(config.startHour).padStart(2, '0')}:00-${String(config.endHour).padStart(2, '0')}:00 GMT`
+
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        'w-full flex items-center space-x-4 p-4 rounded-lg transition-all',
+        'bg-gray-700 hover:bg-gray-650 cursor-pointer',
+        'border border-transparent hover:border-gray-600'
+      )}
+      aria-label={`${config.name} session performance. Total P&L: ${formatCurrency(session.totalPnL)}. Click for details.`}
+    >
+      {/* Session Name + Active Indicator */}
+      <div className="flex items-center space-x-2 w-40 flex-shrink-0">
+        {isActive && (
+          <span
+            className="w-2 h-2 bg-green-400 rounded-full animate-pulse"
+            aria-label="Currently active session"
+          />
+        )}
+        <div className="flex flex-col items-start">
+          <span className="font-semibold text-white text-sm">{config.name}</span>
+          <span className="text-xs text-gray-400">{sessionHours}</span>
+        </div>
+      </div>
+
+      {/* P&L Amount */}
+      <div className={cn('text-lg font-bold w-28 text-right flex-shrink-0', pnlColorClass)}>
+        {formatCurrency(session.totalPnL)}
+      </div>
+
+      {/* Trade Count Badge */}
+      <Badge variant="neutral" className="flex-shrink-0">
+        {session.tradeCount} {session.tradeCount === 1 ? 'trade' : 'trades'}
+      </Badge>
+
+      {/* Win Rate Badge */}
+      <Badge variant={winRateVariant} className="flex-shrink-0">
+        {session.winRate.toFixed(0)}% WR
+      </Badge>
+
+      {/* Confidence Threshold Badge */}
+      <Badge variant="info" className="flex-shrink-0">
+        {session.confidenceThreshold}% conf
+      </Badge>
+
+      {/* Horizontal Bar Chart */}
+      <div className="flex-1 min-w-0">
+        <div className="h-6 bg-gray-600 rounded-full overflow-hidden">
+          <div
+            className={cn(
+              'h-full transition-all duration-500 ease-out',
+              barColorClass
+            )}
+            style={{ width: `${barWidth}%` }}
+            aria-label={`Performance bar representing ${session.totalPnL > 0 ? 'profit' : 'loss'} of ${formatCurrency(session.totalPnL)}`}
+          />
+        </div>
+      </div>
+    </button>
+  )
+}
+
+export default SessionRow

--- a/dashboard/components/performance/WinRateGauge.tsx
+++ b/dashboard/components/performance/WinRateGauge.tsx
@@ -1,0 +1,125 @@
+/**
+ * Win Rate Gauge Component
+ * Circular gauge displaying win rate percentage with color zones
+ */
+
+'use client'
+
+import React, { useMemo } from 'react'
+import { Doughnut } from 'react-chartjs-2'
+import { Chart as ChartJS, ArcElement, Tooltip } from 'chart.js'
+import { cn } from '@/lib/utils'
+
+// Register Chart.js components
+ChartJS.register(ArcElement, Tooltip)
+
+interface WinRateGaugeProps {
+  /** Win rate percentage (0-100) */
+  winRate: number
+  /** Optional size in pixels */
+  size?: number
+}
+
+/**
+ * Determine color zone based on win rate
+ */
+function getWinRateZone(winRate: number): {
+  color: string
+  label: string
+  textColor: string
+} {
+  if (winRate >= 60) {
+    return {
+      color: '#4ade80', // green-400
+      label: 'Excellent',
+      textColor: 'text-green-400'
+    }
+  } else if (winRate >= 40) {
+    return {
+      color: '#fbbf24', // yellow-400
+      label: 'Average',
+      textColor: 'text-yellow-400'
+    }
+  } else {
+    return {
+      color: '#f87171', // red-400
+      label: 'Needs Improvement',
+      textColor: 'text-red-400'
+    }
+  }
+}
+
+/**
+ * Win rate gauge component
+ */
+export function WinRateGauge({ winRate, size = 180 }: WinRateGaugeProps) {
+  const zone = useMemo(() => getWinRateZone(winRate), [winRate])
+
+  // Chart data for doughnut
+  const chartData = useMemo(() => ({
+    datasets: [
+      {
+        data: [winRate, 100 - winRate],
+        backgroundColor: [zone.color, '#374151'], // gray-700
+        borderWidth: 0,
+        circumference: 180,
+        rotation: 270
+      }
+    ]
+  }), [winRate, zone.color])
+
+  // Chart options
+  const chartOptions = useMemo(() => ({
+    responsive: true,
+    maintainAspectRatio: true,
+    cutout: '70%',
+    plugins: {
+      tooltip: {
+        enabled: false
+      }
+    }
+  }), [])
+
+  return (
+    <div className="bg-gray-800 rounded-lg p-6 flex flex-col items-center">
+      <h3 className="text-lg font-semibold text-white mb-4">Win Rate</h3>
+
+      {/* Gauge Chart */}
+      <div className="relative" style={{ width: size, height: size }}>
+        <Doughnut data={chartData} options={chartOptions} />
+
+        {/* Center Text */}
+        <div className="absolute inset-0 flex items-center justify-center" style={{ top: '25%' }}>
+          <div className="text-center">
+            <div className="text-4xl font-bold text-white">
+              {winRate.toFixed(1)}%
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Interpretation Label */}
+      <div className={cn('mt-4 text-sm font-medium', zone.textColor)}>
+        {zone.label}
+      </div>
+
+      {/* Color Legend */}
+      <div className="mt-4 flex items-center space-x-4 text-xs text-gray-400">
+        <div className="flex items-center space-x-1">
+          <div className="w-3 h-3 rounded-full bg-red-400" />
+          <span>&lt;40%</span>
+        </div>
+        <div className="flex items-center space-x-1">
+          <div className="w-3 h-3 rounded-full bg-yellow-400" />
+          <span>40-60%</span>
+        </div>
+        <div className="flex items-center space-x-1">
+          <div className="w-3 h-3 rounded-full bg-green-400" />
+          <span>&gt;60%</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default WinRateGauge

--- a/dashboard/hooks/useEquityCurve.ts
+++ b/dashboard/hooks/useEquityCurve.ts
@@ -1,0 +1,144 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { EquityCurveData, EquityPoint, EquityCurveResponse } from '@/types/metrics'
+
+interface UseEquityCurveOptions {
+  days?: number
+  orchestratorUrl?: string
+}
+
+interface UseEquityCurveReturn {
+  equityCurve: EquityCurveData | null
+  isLoading: boolean
+  error: string | null
+  refetch: () => Promise<void>
+}
+
+/**
+ * Hook for fetching equity curve data
+ * @param options - Configuration options including number of days
+ * @returns Equity curve state and methods
+ */
+export function useEquityCurve({
+  days = 30,
+  orchestratorUrl = 'http://localhost:8089'
+}: UseEquityCurveOptions = {}): UseEquityCurveReturn {
+  const [equityCurve, setEquityCurve] = useState<EquityCurveData | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  /**
+   * Calculate peak and trough from equity points
+   */
+  const calculateMilestones = useCallback((points: EquityPoint[]): EquityCurveData => {
+    if (points.length === 0) {
+      return {
+        points: [],
+        peak: null,
+        trough: null,
+        currentDrawdown: 0,
+        maxDrawdown: 0
+      }
+    }
+
+    // Find peak (highest equity point)
+    const peak = points.reduce((max, point) =>
+      point.equity > max.equity ? point : max,
+      points[0]
+    )
+
+    // Find trough (lowest equity point after peak)
+    const peakIndex = points.findIndex(p => p.date === peak.date)
+    const pointsAfterPeak = points.slice(peakIndex)
+
+    const trough = pointsAfterPeak.length > 1
+      ? pointsAfterPeak.reduce((min, point) =>
+          point.equity < min.equity ? point : min,
+          pointsAfterPeak[1]
+        )
+      : null
+
+    // Calculate current drawdown
+    const currentEquity = points[points.length - 1].equity
+    const currentDrawdown = peak.equity > 0
+      ? ((currentEquity - peak.equity) / peak.equity) * 100
+      : 0
+
+    // Calculate maximum drawdown
+    let maxDrawdown = 0
+    let runningPeak = points[0].equity
+
+    for (const point of points) {
+      if (point.equity > runningPeak) {
+        runningPeak = point.equity
+      }
+
+      const drawdown = runningPeak > 0
+        ? ((point.equity - runningPeak) / runningPeak) * 100
+        : 0
+
+      if (drawdown < maxDrawdown) {
+        maxDrawdown = drawdown
+      }
+    }
+
+    return {
+      points,
+      peak,
+      trough,
+      currentDrawdown,
+      maxDrawdown
+    }
+  }, [])
+
+  /**
+   * Fetch equity curve data from orchestrator
+   */
+  const fetchEquityCurve = useCallback(async () => {
+    try {
+      setIsLoading(true)
+      setError(null)
+
+      const response = await fetch(`${orchestratorUrl}/api/performance/equity-curve?days=${days}`)
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch equity curve: ${response.statusText}`)
+      }
+
+      const result: EquityCurveResponse = await response.json()
+
+      // Map API response to EquityPoint array
+      const points: EquityPoint[] = result.data.map(point => ({
+        date: point.date,
+        equity: point.equity,
+        dailyPnL: point.daily_pnl || point.dailyPnL || 0,
+        drawdown: point.drawdown
+      }))
+
+      // Calculate milestones and drawdowns
+      const curveData = calculateMilestones(points)
+      setEquityCurve(curveData)
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred'
+      setError(errorMessage)
+      console.error('Error fetching equity curve:', err)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [days, orchestratorUrl, calculateMilestones])
+
+  /**
+   * Initial fetch on mount and when days changes
+   */
+  useEffect(() => {
+    fetchEquityCurve()
+  }, [fetchEquityCurve])
+
+  return {
+    equityCurve,
+    isLoading,
+    error,
+    refetch: fetchEquityCurve
+  }
+}

--- a/dashboard/hooks/usePerformanceMetrics.ts
+++ b/dashboard/hooks/usePerformanceMetrics.ts
@@ -1,0 +1,102 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { PerformanceMetrics, MetricsPeriod, PerformanceMetricsResponse } from '@/types/metrics'
+
+interface UsePerformanceMetricsOptions {
+  period?: MetricsPeriod
+  orchestratorUrl?: string
+}
+
+interface UsePerformanceMetricsReturn {
+  metrics: PerformanceMetrics | null
+  previousMetrics: PerformanceMetrics | null
+  isLoading: boolean
+  error: string | null
+  refetch: () => Promise<void>
+}
+
+/**
+ * Hook for fetching performance metrics (win rate, profit factor, etc.)
+ * @param options - Configuration options including time period
+ * @returns Performance metrics state and methods
+ */
+export function usePerformanceMetrics({
+  period = '30d',
+  orchestratorUrl = 'http://localhost:8089'
+}: UsePerformanceMetricsOptions = {}): UsePerformanceMetricsReturn {
+  const [metrics, setMetrics] = useState<PerformanceMetrics | null>(null)
+  const [previousMetrics, setPreviousMetrics] = useState<PerformanceMetrics | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  /**
+   * Fetch performance metrics from orchestrator
+   */
+  const fetchMetrics = useCallback(async () => {
+    try {
+      setIsLoading(true)
+      setError(null)
+
+      const response = await fetch(`${orchestratorUrl}/api/performance/metrics?period=${period}`)
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch metrics: ${response.statusText}`)
+      }
+
+      const data: PerformanceMetricsResponse = await response.json()
+
+      // Map API response to PerformanceMetrics
+      const currentMetrics: PerformanceMetrics = {
+        winRate: data.current.win_rate || data.current.winRate || 0,
+        profitFactor: data.current.profit_factor || data.current.profitFactor || 0,
+        avgWin: data.current.avg_win || data.current.avgWin || 0,
+        avgLoss: Math.abs(data.current.avg_loss || data.current.avgLoss || 0),
+        avgRiskReward: data.current.avg_risk_reward || data.current.avgRiskReward ||
+                      (data.current.avg_win && data.current.avg_loss
+                        ? Math.abs(data.current.avg_win / data.current.avg_loss)
+                        : 0),
+        avgDurationHours: data.current.avg_duration_hours || data.current.avgDurationHours || 0
+      }
+
+      setMetrics(currentMetrics)
+
+      // Set previous metrics if available (for comparison)
+      if (data.previous) {
+        const prevMetrics: PerformanceMetrics = {
+          winRate: data.previous.win_rate || data.previous.winRate || 0,
+          profitFactor: data.previous.profit_factor || data.previous.profitFactor || 0,
+          avgWin: data.previous.avg_win || data.previous.avgWin || 0,
+          avgLoss: Math.abs(data.previous.avg_loss || data.previous.avgLoss || 0),
+          avgRiskReward: data.previous.avg_risk_reward || data.previous.avgRiskReward ||
+                        (data.previous.avg_win && data.previous.avg_loss
+                          ? Math.abs(data.previous.avg_win / data.previous.avg_loss)
+                          : 0),
+          avgDurationHours: data.previous.avg_duration_hours || data.previous.avgDurationHours || 0
+        }
+        setPreviousMetrics(prevMetrics)
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred'
+      setError(errorMessage)
+      console.error('Error fetching performance metrics:', err)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [period, orchestratorUrl])
+
+  /**
+   * Initial fetch on mount and when period changes
+   */
+  useEffect(() => {
+    fetchMetrics()
+  }, [fetchMetrics])
+
+  return {
+    metrics,
+    previousMetrics,
+    isLoading,
+    error,
+    refetch: fetchMetrics
+  }
+}

--- a/dashboard/hooks/useSessionPerformance.ts
+++ b/dashboard/hooks/useSessionPerformance.ts
@@ -1,0 +1,186 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { TradingSession, SessionPerformance, DateRange, SESSION_CONFIG, TradeCompletedMessage } from '@/types/session'
+import { useWebSocket } from './useWebSocket'
+
+interface UseSessionPerformanceOptions {
+  dateRange: DateRange
+  orchestratorUrl?: string
+  enableRealtime?: boolean
+}
+
+interface UseSessionPerformanceReturn {
+  sessions: SessionPerformance[]
+  activeSession: TradingSession | null
+  isLoading: boolean
+  error: string | null
+  refetch: () => Promise<void>
+}
+
+/**
+ * Hook for fetching and managing session performance data
+ * @param options - Configuration options including date range
+ * @returns Session performance state and methods
+ */
+export function useSessionPerformance({
+  dateRange,
+  orchestratorUrl = 'http://localhost:8089',
+  enableRealtime = true
+}: UseSessionPerformanceOptions): UseSessionPerformanceReturn {
+  const [sessions, setSessions] = useState<SessionPerformance[]>([])
+  const [activeSession, setActiveSession] = useState<TradingSession | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // WebSocket for real-time updates
+  const { lastMessage } = useWebSocket({
+    url: orchestratorUrl.replace('http', 'ws'),
+    reconnectAttempts: 5
+  })
+
+  // Throttle ref for WebSocket updates (5-second interval)
+  const lastUpdateRef = useRef<number>(0)
+  const throttleDelay = 5000
+
+  /**
+   * Determine current active session based on GMT time
+   */
+  const determineActiveSession = useCallback((): TradingSession | null => {
+    const now = new Date()
+    const gmtHour = now.getUTCHours()
+
+    for (const [sessionKey, config] of Object.entries(SESSION_CONFIG)) {
+      const { startHour, endHour } = config
+
+      // Handle sessions that cross midnight (e.g., Sydney 18:00-03:00)
+      const isActive = startHour <= endHour
+        ? gmtHour >= startHour && gmtHour < endHour
+        : gmtHour >= startHour || gmtHour < endHour
+
+      if (isActive) {
+        return sessionKey as TradingSession
+      }
+    }
+
+    return null
+  }, [])
+
+  /**
+   * Fetch session performance data from orchestrator
+   */
+  const fetchSessionData = useCallback(async () => {
+    try {
+      setIsLoading(true)
+      setError(null)
+
+      const params = new URLSearchParams({
+        start_date: dateRange.start.toISOString(),
+        end_date: dateRange.end.toISOString()
+      })
+
+      const response = await fetch(`${orchestratorUrl}/api/performance/sessions?${params}`)
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch session data: ${response.statusText}`)
+      }
+
+      const data = await response.json()
+
+      // Determine active session
+      const currentActiveSession = determineActiveSession()
+
+      // Map API response to SessionPerformance with active flag
+      const sessionData: SessionPerformance[] = data.sessions.map((s: any) => ({
+        session: s.session as TradingSession,
+        totalPnL: s.total_pnl || s.totalPnL || 0,
+        tradeCount: s.trade_count || s.tradeCount || 0,
+        winCount: s.win_count || s.winCount || 0,
+        winRate: s.win_rate || s.winRate || 0,
+        confidenceThreshold: s.confidence_threshold || s.confidenceThreshold || SESSION_CONFIG[s.session as TradingSession].confidenceThreshold,
+        isActive: s.session === currentActiveSession
+      }))
+
+      setSessions(sessionData)
+      setActiveSession(currentActiveSession)
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred'
+      setError(errorMessage)
+      console.error('Error fetching session data:', err)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [dateRange, orchestratorUrl, determineActiveSession])
+
+  /**
+   * Handle real-time WebSocket updates (throttled)
+   */
+  useEffect(() => {
+    if (!enableRealtime || !lastMessage) return
+
+    const now = Date.now()
+
+    // Throttle updates to 5-second intervals
+    if (now - lastUpdateRef.current < throttleDelay) {
+      return
+    }
+
+    // Check if message is trade completion
+    if (lastMessage.type === 'trade.completed') {
+      const tradeData = lastMessage as unknown as TradeCompletedMessage
+      const { session, pnL } = tradeData.data
+
+      lastUpdateRef.current = now
+
+      setSessions(prev => prev.map(s =>
+        s.session === session
+          ? {
+              ...s,
+              totalPnL: s.totalPnL + pnL,
+              tradeCount: s.tradeCount + 1,
+              winCount: pnL > 0 ? s.winCount + 1 : s.winCount,
+              winRate: pnL > 0
+                ? ((s.winCount + 1) / (s.tradeCount + 1)) * 100
+                : (s.winCount / (s.tradeCount + 1)) * 100
+            }
+          : s
+      ))
+    }
+  }, [lastMessage, enableRealtime])
+
+  /**
+   * Update active session every minute
+   */
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const currentActiveSession = determineActiveSession()
+
+      if (currentActiveSession !== activeSession) {
+        setActiveSession(currentActiveSession)
+
+        // Update isActive flag for all sessions
+        setSessions(prev => prev.map(s => ({
+          ...s,
+          isActive: s.session === currentActiveSession
+        })))
+      }
+    }, 60000) // Check every minute
+
+    return () => clearInterval(interval)
+  }, [activeSession, determineActiveSession])
+
+  /**
+   * Initial fetch and refetch on date range change
+   */
+  useEffect(() => {
+    fetchSessionData()
+  }, [fetchSessionData])
+
+  return {
+    sessions,
+    activeSession,
+    isLoading,
+    error,
+    refetch: fetchSessionData
+  }
+}

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -26,6 +26,7 @@
     "chart.js": "^4.5.0",
     "clsx": "^2.1.1",
     "d3": "^7.9.0",
+    "date-fns": "^4.1.0",
     "framer-motion": "^12.23.12",
     "js-cookie": "^3.0.5",
     "jsonwebtoken": "^9.0.2",

--- a/dashboard/types/metrics.ts
+++ b/dashboard/types/metrics.ts
@@ -1,0 +1,156 @@
+/**
+ * Performance Metrics Type Definitions
+ * Types for win rate, profit factor, trade statistics, and equity tracking
+ */
+
+/**
+ * Performance metrics data structure
+ */
+export interface PerformanceMetrics {
+  /** Win rate percentage (0-100) */
+  winRate: number
+  /** Profit factor (gross profit / gross loss) */
+  profitFactor: number
+  /** Average winning trade amount */
+  avgWin: number
+  /** Average losing trade amount */
+  avgLoss: number
+  /** Average risk-reward ratio */
+  avgRiskReward: number
+  /** Average trade duration in hours */
+  avgDurationHours: number
+}
+
+/**
+ * Profit factor interpretation
+ */
+export type ProfitFactorRating = 'excellent' | 'good' | 'fair' | 'poor'
+
+/**
+ * Profit factor display data
+ */
+export interface ProfitFactorDisplay {
+  /** Profit factor value */
+  value: number
+  /** Rating based on value */
+  rating: ProfitFactorRating
+  /** Display color */
+  color: string
+  /** Interpretation label */
+  label: string
+}
+
+/**
+ * Average trade metrics comparison
+ */
+export interface TradeMetricsComparison {
+  /** Current period average win */
+  currentAvgWin: number
+  /** Previous period average win */
+  previousAvgWin: number
+  /** Current period average loss */
+  currentAvgLoss: number
+  /** Previous period average loss */
+  previousAvgLoss: number
+  /** Current period average R:R */
+  currentAvgRR: number
+  /** Previous period average R:R */
+  previousAvgRR: number
+  /** Current period average duration */
+  currentAvgDuration: number
+  /** Previous period average duration */
+  previousAvgDuration: number
+}
+
+/**
+ * Equity curve data point
+ */
+export interface EquityPoint {
+  /** Date */
+  date: string
+  /** Account equity at this date */
+  equity: number
+  /** Daily P&L */
+  dailyPnL: number
+  /** Current drawdown percentage */
+  drawdown?: number
+}
+
+/**
+ * Equity curve milestone markers
+ */
+export interface EquityMilestone {
+  /** Date of milestone */
+  date: string
+  /** Equity value at milestone */
+  equity: number
+  /** Milestone type */
+  type: 'peak' | 'trough' | 'drawdown'
+}
+
+/**
+ * Equity curve data structure
+ */
+export interface EquityCurveData {
+  /** Array of equity points */
+  points: EquityPoint[]
+  /** Peak equity point */
+  peak: EquityPoint | null
+  /** Trough equity point (lowest after peak) */
+  trough: EquityPoint | null
+  /** Current drawdown percentage */
+  currentDrawdown: number
+  /** Maximum drawdown percentage */
+  maxDrawdown: number
+}
+
+/**
+ * Win rate gauge zone
+ */
+export type WinRateZone = 'poor' | 'average' | 'good'
+
+/**
+ * Win rate gauge data
+ */
+export interface WinRateGaugeData {
+  /** Win rate percentage */
+  percentage: number
+  /** Color zone */
+  zone: WinRateZone
+  /** Display color */
+  color: string
+}
+
+/**
+ * Metrics period for comparison
+ */
+export type MetricsPeriod = '7d' | '30d' | '90d' | 'all'
+
+/**
+ * Performance metrics API response
+ */
+export interface PerformanceMetricsResponse {
+  /** Current period metrics */
+  current: PerformanceMetrics
+  /** Previous period metrics (for comparison) */
+  previous?: PerformanceMetrics
+}
+
+/**
+ * Equity curve API response
+ */
+export interface EquityCurveResponse {
+  /** Equity curve data */
+  data: EquityPoint[]
+}
+
+/**
+ * CSV export data structure
+ */
+export interface SessionCSVData {
+  session: string
+  totalPnL: number
+  tradeCount: number
+  winRate: number
+  confidenceThreshold: number
+}

--- a/dashboard/types/session.ts
+++ b/dashboard/types/session.ts
@@ -1,0 +1,137 @@
+/**
+ * Trading Session Type Definitions
+ * Types for session-based performance tracking and analysis
+ */
+
+/**
+ * Trading session identifiers
+ */
+export enum TradingSession {
+  SYDNEY = 'sydney',
+  TOKYO = 'tokyo',
+  LONDON = 'london',
+  NEW_YORK = 'new_york',
+  OVERLAP = 'overlap'
+}
+
+/**
+ * Session configuration and metadata
+ */
+export interface SessionConfig {
+  /** Display name */
+  name: string
+  /** Session start hour (GMT) */
+  startHour: number
+  /** Session end hour (GMT) */
+  endHour: number
+  /** Theme color for UI */
+  color: string
+  /** Confidence threshold percentage */
+  confidenceThreshold: number
+}
+
+/**
+ * Session configuration mapping
+ */
+export const SESSION_CONFIG: Record<TradingSession, SessionConfig> = {
+  [TradingSession.SYDNEY]: {
+    name: 'Sydney',
+    startHour: 18,
+    endHour: 3,
+    color: 'purple',
+    confidenceThreshold: 78
+  },
+  [TradingSession.TOKYO]: {
+    name: 'Tokyo',
+    startHour: 0,
+    endHour: 9,
+    color: 'red',
+    confidenceThreshold: 85
+  },
+  [TradingSession.LONDON]: {
+    name: 'London',
+    startHour: 7,
+    endHour: 16,
+    color: 'blue',
+    confidenceThreshold: 72
+  },
+  [TradingSession.NEW_YORK]: {
+    name: 'New York',
+    startHour: 12,
+    endHour: 21,
+    color: 'green',
+    confidenceThreshold: 70
+  },
+  [TradingSession.OVERLAP]: {
+    name: 'Overlap',
+    startHour: 12,
+    endHour: 16,
+    color: 'orange',
+    confidenceThreshold: 70
+  }
+}
+
+/**
+ * Session performance data structure
+ */
+export interface SessionPerformance {
+  /** Session identifier */
+  session: TradingSession
+  /** Total P&L for session */
+  totalPnL: number
+  /** Number of trades executed */
+  tradeCount: number
+  /** Number of winning trades */
+  winCount: number
+  /** Win rate percentage */
+  winRate: number
+  /** Confidence threshold used */
+  confidenceThreshold: number
+  /** Is currently active session */
+  isActive: boolean
+}
+
+/**
+ * Date range for filtering
+ */
+export interface DateRange {
+  /** Start date */
+  start: Date
+  /** End date */
+  end: Date
+}
+
+/**
+ * Date range preset options
+ */
+export type DateRangePreset = 'today' | 'week' | 'month' | 'custom'
+
+/**
+ * Session detail trade information
+ */
+export interface SessionTrade {
+  /** Trade ID */
+  id: string
+  /** Timestamp */
+  timestamp: Date
+  /** Trading instrument */
+  instrument: string
+  /** Trade direction */
+  direction: 'long' | 'short'
+  /** Profit/loss */
+  pnL: number
+  /** Trade duration in seconds */
+  duration: number
+}
+
+/**
+ * WebSocket trade completion message
+ */
+export interface TradeCompletedMessage {
+  type: 'trade.completed'
+  data: {
+    session: string
+    pnL: number
+    timestamp: string
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "chart.js": "^4.5.0",
         "clsx": "^2.1.1",
         "d3": "^7.9.0",
+        "date-fns": "^4.1.0",
         "framer-motion": "^12.23.12",
         "js-cookie": "^3.0.5",
         "jsonwebtoken": "^9.0.2",
@@ -5121,6 +5122,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {


### PR DESCRIPTION
## 📊 Story 3.3: Session Performance & Metrics Dashboard

This PR implements comprehensive session-based performance tracking and key trading metrics visualization for the dashboard.

### 🎯 Overview

As a trader using session-targeted trading strategies, I need a session performance breakdown widget and comprehensive metrics dashboard, so that I can identify which trading sessions are most profitable and track key performance indicators over time.

### ✨ Features Implemented

#### Session Performance Widget
- ✅ P&L breakdown for 5 trading sessions (Sydney, Tokyo, London, New York, Overlap)
- ✅ Active session indicator with glowing dot (GMT-based detection)
- ✅ Date range filtering: Today | This Week | This Month | Custom Range
- ✅ Horizontal bar charts showing P&L relative to other sessions
- ✅ Session drill-down modal with detailed trade list
- ✅ CSV export functionality
- ✅ Real-time WebSocket updates (5-second throttle)

#### Performance Metrics Dashboard
- ✅ Win Rate Gauge - Circular gauge with color zones (red <40%, yellow 40-60%, green >60%)
- ✅ Profit Factor Display - Large number with interpretation (Excellent/Good/Fair/Poor)
- ✅ Average Trade Metrics - 4-stat grid with period-over-period comparison
- ✅ 30-Day Equity Curve - Line chart with peak/trough markers

### 📁 Files Changed

**New Frontend Components (13 files):**
```
dashboard/types/
├── session.ts              # Trading session types and config
└── metrics.ts              # Performance metrics types

dashboard/hooks/
├── useSessionPerformance.ts   # Session P&L data fetching
├── usePerformanceMetrics.ts   # Win rate, profit factor, etc.
└── useEquityCurve.ts          # 30-day equity curve

dashboard/components/performance/
├── SessionPerformanceWidget.tsx      # Main session widget
├── SessionRow.tsx                    # Individual session row
├── SessionDetailModal.tsx            # Session drill-down
├── WinRateGauge.tsx                  # Circular win rate gauge
├── ProfitFactorDisplay.tsx           # Profit factor display
├── AverageTradeMetrics.tsx           # Average trade stats
├── EquityCurveChart.tsx              # 30-day equity curve
└── PerformanceMetricsDashboard.tsx   # Metrics dashboard
```

**Backend Enhancements:**
```
orchestrator/app/performance_routes.py
├── GET /api/performance/sessions          # Session P&L breakdown
├── GET /api/performance/session-trades    # Trades for specific session
├── GET /api/performance/metrics           # Performance metrics
└── GET /api/performance/equity-curve      # 30-day equity data
```

**Test Files:**
```
dashboard/__tests__/
├── components/performance/SessionPerformanceWidget.test.tsx
└── hooks/useSessionPerformance.test.ts
```

### 🧪 Testing

- ✅ Unit tests for SessionPerformanceWidget component
- ✅ Unit tests for useSessionPerformance hook  
- ✅ All 5 tests passing
- ✅ No linting errors in new files
- ✅ TypeScript types properly defined
- ✅ Dev server compiles successfully (1774 modules)

### 📊 Statistics

- **19 files changed**
- **2,796 insertions**, 6 deletions
- **13 new components/hooks/types**
- **4 new backend endpoints**
- **2 test files with 5 passing tests**

### 🔧 Dependencies Added

- `date-fns` - For date manipulation in components

### 🚀 Integration

Components integrated into `/performance-analytics` page:
- Session Performance Widget displays at top
- Performance Metrics Dashboard shows below
- Existing Performance Analytics Dashboard remains functional

### ✅ Acceptance Criteria Met

All 15 acceptance criteria from Story 3.3 have been implemented:
1. ✅ Session Performance Breakdown widget displays on main dashboard
2. ✅ Widget shows P&L for each of 5 trading sessions
3. ✅ Each session displays name, P&L, trade count, win rate, confidence threshold, and bar chart
4. ✅ Date range filter: Today | This Week | This Month | Custom Range
5. ✅ Session bars color-coded: green (profitable), red (unprofitable), gray (no trades)
6. ✅ Click session to drill down into trades for that session
7. ✅ Performance Metrics Dashboard section with 4 key widgets
8. ✅ Win Rate Gauge: Visual gauge from 0-100% with color zones
9. ✅ Profit Factor: Large number display with interpretation
10. ✅ Average Trade Metrics: 4-stat grid with comparisons to previous period
11. ✅ Equity Curve: Line chart with milestone markers
12. ✅ Real-time updates: Session P&L updates as trades complete (5-second interval)
13. ✅ Export functionality: Download session data as CSV
14. ✅ Loading states: Skeleton widgets while fetching data
15. ✅ Existing dashboard layout unaffected

### 📸 How to Test

1. Start the dashboard: `cd dashboard && npm run dev`
2. Navigate to: `http://localhost:8090/performance-analytics`
3. Verify Session Performance Widget displays with 5 sessions
4. Test date range filters (Today/Week/Month/Custom)
5. Click on a session row to open drill-down modal
6. Verify Performance Metrics Dashboard shows below with 4 widgets
7. Confirm all components render correctly and data loads

### 🎨 Design Patterns

- Follows existing dashboard styling (Tailwind CSS, dark theme)
- Uses chart.js/react-chartjs-2 for visualizations
- Implements loading skeletons for better UX
- WebSocket integration with throttling (5s interval)
- Responsive layout with proper error handling

### 📝 Notes

- GMT timezone used consistently for session detection
- Session configuration matches system requirements from CLAUDE.md
- Backend reuses existing TradingSession enum from orchestrator models
- No regression in existing dashboard functionality

---

**Story Status:** Ready for Review  
**Story Owner:** James (Dev Agent)  
**Story:** 3.3 Session Performance & Metrics Dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)